### PR TITLE
Fix snazzy headers

### DIFF
--- a/sass/columns.scss
+++ b/sass/columns.scss
@@ -38,20 +38,21 @@
   line-height: 50px;
 }
 
-.column-title {
-  padding-top: 5px;
-  line-height: 1.4em;
-  text-align: center;
-}
 
-.column-title .column-head-title {
-  font-weight: bold;
-}
-
-.column-title .attribution {
-  display: block;
-  line-height: 1em;
-  margin-top: -3px;
+@if $header-height > 43px {
+	.column-title {
+	  padding-top: 5px;
+	  line-height: 1.4em;
+	  text-align: center;
+	}
+	.column-title .column-head-title {
+	  font-weight: bold;
+	}
+	.column-title .attribution {
+	  display: block;
+	  line-height: 1em;
+	  margin-top: -3px;
+	}
 }
 
 .column-drag-handle {


### PR DESCRIPTION
They spill out of the header when you have a header height less than
44px. That piece of code now only triggers when one's header height is
large enough - allowing old cashmere-style compact headers